### PR TITLE
Allow more recent versions of symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
   ],
   "require": {
     "php": ">=5.3.0",
-    "symfony/yaml": "2.2.1"
+    "symfony/yaml": "~2.2"
   }
 }


### PR DESCRIPTION
Let's see if things work with the latest stable version after 2.2.
