### PR TITLE
Info override

### DIFF
--- a/bandaid.drush.inc
+++ b/bandaid.drush.inc
@@ -295,6 +295,8 @@ function drush_bandaid_patch($patch = NULL, $project = NULL) {
     }
 
     $project['yaml']['patches'][] = $new_patch;
+
+    // Make sure the yaml-file is up to date.
     _bandaid_write_yaml($project);
   }
   catch (BandaidError $e) {
@@ -348,10 +350,8 @@ function drush_bandaid_tearoff($project = NULL) {
         throw new BandaidError('CANNOT_CREATE_PATCH', dt('Error creating file @patch_file', array('@patch_file' => $project['local_patch_file'])));
       }
 
-      // If everything went ok and we have an override.
-      if (drush_get_option('info-file', FALSE)) {
-        _bandaid_write_yaml($project);
-      }
+      // Make sure the yaml-file is up to date.
+      _bandaid_write_yaml($project);
     }
   }
   catch (BandaidError $e) {
@@ -1207,10 +1207,22 @@ function _bandaid_ignore_callback_7($path) {
  * Writes the [projectname].yml file.
  */
 function _bandaid_write_yaml($project) {
-  // Persist the information about the override to the yaml-file if it is not
-  // already in the file.
+  if (empty($project['yaml'])) {
+    return;
+  }
+
+  // Prepare the output.
+  $new_yaml = Yaml::dump($project['yaml'], 4, 2);
+
+  $current_yaml = FALSE;
+  // Get the current contents of the file.
+  if (file_exists($project['yaml_file'])) {
+    $current_yaml = Yaml::parse($project['yaml_file']);
+  }
+
+  // Write the yaml if we have any new content.
   // Only switch to inline format at level 4.
-  if (!file_put_contents($project['yaml_file'], Yaml::dump($project['yaml'], 4, 2))) {
+  if ($new_yaml != $current_yaml && !file_put_contents($project['yaml_file'], $new_yaml)) {
     throw new BandaidError('CANNOT_WRITE_YAML', dt('Error writing new YAML file @file', array('@file' => $project['yaml_file'])));
   }
 }

--- a/tests/bandaidTest.php
+++ b/tests/bandaidTest.php
@@ -65,6 +65,7 @@ class BandaidFunctionalTestCase extends CommandUnishTestCase {
     $options = array(
       'home' => 'https://drupal.org/node/1985980',
       'reason' => 'For altering of new panes.',
+      'info-file' => 'panels.info',
     );
     $patch1_string = 'drupal_alter(\'panels_new_pane\', $pane);';
     $this->assertEmpty($this->grep($patch1_string, $workdir . '/panels'));
@@ -77,9 +78,13 @@ class BandaidFunctionalTestCase extends CommandUnishTestCase {
     // And that the patch was added.
     $this->assertFileContains($workdir . '/panels.yml', 'https://drupal.org/files/issues/panels-new-pane-alter-1985980-5.patch');
 
+    // And that we have a info-file entry.
+    $this->assertFileContains($workdir . '/panels.yml', 'panels.info');
+
     $options = array(
       'home' => 'https://drupal.org/node/2098515',
       'reason' => 'To avoid notice.',
+      'info-file' => 'panels.info',
     );
     $patch2_string = 'if (!isset($pane->type)) {';
     $this->assertEmpty($this->grep($patch2_string, $workdir . '/panels'));
@@ -88,6 +93,9 @@ class BandaidFunctionalTestCase extends CommandUnishTestCase {
 
     // Check that yaml file has been updated.
     $this->assertFileContains($workdir . '/panels.yml', 'https://drupal.org/files/issues/undefined_property_notices_fix-2098515-2.patch');
+
+    // And that we have a info-file entry.
+    $this->assertFileContains($workdir . '/panels.yml', 'panels.info');
 
     // Add a local modification to the module file.
     $content = file_get_contents($workdir . '/panels/panels.module');
@@ -104,11 +112,19 @@ class BandaidFunctionalTestCase extends CommandUnishTestCase {
     $this->assertNotEmpty($this->grep($patch2_string, $workdir . '/panels'));
     $this->assertNotEmpty($this->grep('\$var = \"Local modification.\";', $workdir . '/panels'));
 
-    // Tearoff the patches and check that they're gone.
-    $this->drush('bandaid-tearoff', array('panels'), array(), NULL, $workdir);
+    // And that we have a info-file entry.
+    $this->assertFileContains($workdir . '/panels.yml', 'panels.info');
+
+    $options = array(
+      'info-file' => 'panels.info',
+    );
+    $this->drush('bandaid-tearoff', array('panels'), $options, NULL, $workdir);
     $this->assertEmpty($this->grep($patch1_string, $workdir . '/panels'));
     $this->assertEmpty($this->grep($patch2_string, $workdir . '/panels'));
     $this->assertEmpty($this->grep('\$var = \"Local modification.\";', $workdir . '/panels'));
+
+    // And that we have a info-file entry.
+    $this->assertFileContains($workdir . '/panels.yml', 'panels.info');
 
     $local_patch = $workdir . '/panels.local.patch';
     // Ensure that we got a local patch file and it contains the expected.


### PR DESCRIPTION
Makes it possible to override which info-file bandaid uses on the commandline.
The override is persisted into the yaml-file for future use.
